### PR TITLE
Added iOS dependency to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ To link the project, please run
 ```
 react-native link @gregfrench/react-native-wheel-picker
 ```
+For iOS install the dependency
+```
+npm i @react-native-picker/picker --save
+
+cd ios && pod install && cd .. 
+```
 
 ## Example code (using functional components)
 ```


### PR DESCRIPTION
This prevents -> Invariant Violation: requireNativeComponent: "RNCPicker" was not found in the UIManager.