### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ react-native link @gregfrench/react-native-wheel-picker
 CocoaPods on iOS needs this extra step:
 
 ```
+yarn add @react-native-picker/picker
 cd ios && pod install && cd ..
 ```
 


### PR DESCRIPTION
Noticed that I got a runtime error since RNCPicker could not be imported. Adding it to my own package.json, caused "pod install" to properly fetch the dependency. Hence this commit was made.