### PR TITLE
build.gradle minSdk fix for detox issues

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 28
     buildToolsVersion "28.0.3"
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion rootProject.hasProperty('minSdkVersion') ? rootProject.minSdkVersion : 16
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
Detox has these issues with libraries hardcoded with minSdk of 16 
https://github.com/wix/Detox/issues/2712
 uses-sdk:minSdkVersion 16 cannot be smaller than version 21 declared in library [com.facebook.react:react-native:0.64.1] ~/.gradle/caches/transforms-2/files-2.1/78506b10b159cf516bb672f491c3adb5/jetified-react-native-0.64.1/AndroidManifest.xml as the library might be using APIs not available in 16
        Suggestion: use a compatible library with a minSdk of at most 16,
                or increase this project's minSdk version to at least 21,
                or use tools:overrideLibrary="com.facebook.react" to force usage (may lead to runtime failures)